### PR TITLE
feature/OMO-48/매장 상세 페이지 기본 마크업 작성 (동적 라우팅)

### DIFF
--- a/src/components/StoreDescription/StoreDescription.tsx
+++ b/src/components/StoreDescription/StoreDescription.tsx
@@ -1,0 +1,44 @@
+import { DetailPageProps } from '@pages/search/[id]';
+
+import * as S from './styles';
+
+interface StoreDescriptionProps {
+  store: DetailPageProps;
+}
+
+const StoreDescription = ({ store }: StoreDescriptionProps) => {
+  return (
+    <S.StoreDescription>
+      <div className="content-wrapper">
+        <h1 className="list title">{store.name}</h1>
+        <pre className="list desc">{store.desc}</pre>
+        <div className="list sub-contents">
+          <p className="sub-title">위치 :</p>
+          <p>{store.location}</p>
+        </div>
+        <div className="list sub-contents">
+          <p className="sub-title">전화번호 :</p>
+          <p>{store.tel}</p>
+        </div>
+        <div className="list sub-contents">
+          <p className="sub-title">가격대 :</p>
+          <p>{store.price}</p>
+        </div>
+        <div className="list hashtag-wrapper">
+          {store.types.map((type) => (
+            <S.HashTag key={type}>#{type}</S.HashTag>
+          ))}
+        </div>
+      </div>
+
+      <div className="button-wrapper">
+        <S.Button onClick={() => alert('문의중...')}>예약 문의 하기</S.Button>
+        <S.Button onClick={() => alert('깨는중...')} bgColor="#c9c9c9">
+          이 가게 도장깨기
+        </S.Button>
+      </div>
+    </S.StoreDescription>
+  );
+};
+
+export default StoreDescription;

--- a/src/components/StoreDescription/index.tsx
+++ b/src/components/StoreDescription/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './StoreDescription';

--- a/src/components/StoreDescription/styles.ts
+++ b/src/components/StoreDescription/styles.ts
@@ -1,0 +1,86 @@
+import styled from 'styled-components';
+
+interface ButtonProps {
+  bgColor?: string;
+}
+
+export const StoreDescription = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transform: translateY(-30px);
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  background-color: #fff;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 21px;
+  margin-bottom: -30px;
+
+  .content-wrapper {
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 140%;
+    font-family: 'Noto Sans KR', sans-serif;
+    color: #444;
+  }
+
+  .list {
+    margin-bottom: 16px;
+  }
+
+  .title {
+    font-size: 20px;
+    font-weight: bold;
+    line-height: 140%;
+    font-family: 'Noto Sans KR', sans-serif;
+    margin-bottom: 10px;
+    color: #444;
+  }
+
+  .sub-contents {
+    display: flex;
+
+    .sub-title {
+      padding-right: 10px;
+      white-space: nowrap;
+    }
+  }
+
+  .hashtag-wrapper {
+    display: flex;
+  }
+
+  .button-wrapper {
+  }
+`;
+
+export const HashTag = styled.span`
+  border-radius: 20px;
+  padding: 6px 15px;
+  background-color: #f0f0f0;
+
+  & + & {
+    margin-left: 10px;
+  }
+`;
+
+export const Button = styled.button<ButtonProps>`
+  width: 100%;
+  padding: 16px;
+  color: #4b4b4b;
+  outline: none;
+  border: none;
+  border-radius: 12px;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 140%;
+  font-family: 'Noto Sans KR', sans-serif;
+  background-color: ${({ bgColor }) => (bgColor ? bgColor : 'transparent')};
+  border: ${({ bgColor }) => (bgColor ? 'none' : '1px solid #9e9e9e')};
+
+  & + & {
+    margin-top: 14px;
+  }
+`;

--- a/src/components/StoreDisplay/StoreDisplay.tsx
+++ b/src/components/StoreDisplay/StoreDisplay.tsx
@@ -1,32 +1,37 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 import * as S from './styles';
 
 export interface StoreDisplayProps {
-  id?: number;
+  id: number;
+  types: string[];
   image: string;
-  location: string;
-  type: string;
   name: string;
   desc: string;
 }
 
-const StoreDisplay = ({ image, location, type, name, desc }: StoreDisplayProps) => {
+const StoreDisplay = ({ id, image, types, name, desc }: StoreDisplayProps) => {
   return (
     <S.StoreDisplay>
-      <S.StoreImageWrapper>
-        <S.SubTitles>
-          <span>{location}</span>
-          <span>{type}</span>
-        </S.SubTitles>
+      <Link href={`/search/${id}`} passHref>
+        <a>
+          <S.StoreImageWrapper>
+            <S.SubTitles>
+              {types.map((type) => (
+                <span key={type}>{type}</span>
+              ))}
+            </S.SubTitles>
 
-        <Image src={image} alt="매장 이미지 미리보기" layout="fill" />
-      </S.StoreImageWrapper>
+            <Image src={image} alt="매장 이미지 미리보기" layout="fill" />
+          </S.StoreImageWrapper>
 
-      <S.StoreDescriptionWrapper>
-        <h1 className="store-title">{name}</h1>
-        <pre className="store-desc">{desc}</pre>
-      </S.StoreDescriptionWrapper>
+          <S.StoreDescriptionWrapper>
+            <h1 className="store-title">{name}</h1>
+            <pre className="store-desc">{desc}</pre>
+          </S.StoreDescriptionWrapper>
+        </a>
+      </Link>
     </S.StoreDisplay>
   );
 };

--- a/src/components/StoreDisplay/styles.ts
+++ b/src/components/StoreDisplay/styles.ts
@@ -4,6 +4,11 @@ export const StoreDisplay = styled.section`
   display: flex;
   flex-direction: column;
   margin-bottom: 1rem;
+
+  a {
+    text-decoration: none;
+    color: #444;
+  }
 `;
 
 export const StoreImageWrapper = styled.div`
@@ -22,6 +27,12 @@ export const SubTitles = styled.div`
   top: 1rem;
   right: 1rem;
   gap: 0.5rem;
+
+  span {
+    padding: 0.2rem 0.4rem;
+    border-radius: 1rem;
+    background-color: #ffffffb3;
+  }
 `;
 
 export const StoreDescriptionWrapper = styled.div`

--- a/src/pages/search/[id].tsx
+++ b/src/pages/search/[id].tsx
@@ -1,7 +1,59 @@
 // 매장 상세페이지 관련
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
 
-const detail = () => {
-  return <div>아이디</div>;
+import StoreDescription from '@components/StoreDescription';
+import { StoreDisplayProps } from '@components/StoreDisplay/StoreDisplay';
+import { dummys } from '@temp/SearchListDummy';
+
+export interface DetailPageProps extends StoreDisplayProps {
+  location: string;
+  tel: string;
+  price: string;
+}
+
+const Detail = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const [임시, 셋임시] = useState<DetailPageProps>();
+
+  useEffect(() => {
+    function fetchSelectedData(id: string) {
+      return dummys.filter((dummy) => dummy.id === +id)[0];
+    }
+
+    const temp = fetchSelectedData(id as string);
+    셋임시(temp);
+  }, [id]);
+
+  if (!임시) {
+    return 'loading...';
+  }
+
+  return (
+    <DetailPage>
+      <ImageWrapper>
+        <Image src={임시.image} alt="가게 이미지" layout="fill" />
+      </ImageWrapper>
+
+      <StoreDescription store={임시} />
+    </DetailPage>
+  );
 };
 
-export default detail;
+export default Detail;
+
+const DetailPage = styled.section`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  height: 100vh;
+`;
+
+const ImageWrapper = styled.div`
+  position: relative;
+  height: 240px;
+  width: 100%;
+`;

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -4,7 +4,32 @@ import styled from 'styled-components';
 
 import Layout from '@components/Layout';
 import StoreDisplay from '@components/StoreDisplay';
-import { StoreDisplayProps } from '@components/StoreDisplay/StoreDisplay';
+import { dummys } from '@temp/SearchListDummy';
+
+const Search = () => {
+  return (
+    <Layout title="오마카세 찾기">
+      <SearchPage className="container">
+        <SearchBar>
+          <input type="text" placeholder="위치 / 가게명을 검색해보세요." />
+        </SearchBar>
+
+        {dummys.map((dummy) => (
+          <StoreDisplay
+            key={dummy.id}
+            id={dummy.id}
+            image={dummy.image}
+            types={dummy.types}
+            name={dummy.name}
+            desc={dummy.desc}
+          />
+        ))}
+      </SearchPage>
+    </Layout>
+  );
+};
+
+export default Search;
 
 const SearchPage = styled.section``;
 
@@ -22,58 +47,3 @@ const SearchBar = styled.div`
     width: 100%;
   }
 `;
-
-const index = () => {
-  return (
-    <Layout title="오마카세 찾기">
-      <SearchPage className="container">
-        <SearchBar>
-          <input type="text" placeholder="위치 / 가게명을 검색해보세요." />
-        </SearchBar>
-
-        {dummys.map((dummy) => (
-          <StoreDisplay
-            key={dummy.id}
-            image={dummy.image}
-            location={dummy.location}
-            type={dummy.type}
-            name={dummy.name}
-            desc={dummy.desc}
-          />
-        ))}
-      </SearchPage>
-    </Layout>
-  );
-};
-
-export default index;
-
-const dummys: StoreDisplayProps[] = [
-  {
-    id: 1,
-    image: `https://c2.poing.co.kr/place/image/thumbnail/MjAyMTA5/163100066261371856c2830.jpg`,
-    location: `강남구`,
-    type: `하이엔드`,
-    name: `스시조`,
-    desc: `오마카세 경력 25년의 셰프와 산지직송
-제철 식자재의 정성이 담긴 요리`,
-  },
-  {
-    id: 2,
-    image: `https://c2.poing.co.kr/place/image/service/MjAyMTA5/163101073861373fb28a0a2.jpg`,
-    location: `강남구`,
-    type: `하이엔드`,
-    name: `스시조어진`,
-    desc: `오마카세 경력 25년의 셰프와 산지직송
-제철 식자재의 정성이 담긴 요리`,
-  },
-  {
-    id: 3,
-    image: `https://c2.poing.co.kr/place/image/service/MjAyMTA5/1631000742613718a614ac5.jpg`,
-    location: `은평구`,
-    type: `하이엔드`,
-    name: `조어진스시`,
-    desc: `오마카세 경력 25년의 셰프와 산지직송
-제철 식자재의 정성이 담긴 요리`,
-  },
-];

--- a/src/pages/search/nodata.tsx
+++ b/src/pages/search/nodata.tsx
@@ -1,7 +1,7 @@
 // 아무 데이터가 없는 경우
 
-const nodata = () => {
+const NoData = () => {
   return <div>노 데이타</div>;
 };
 
-export default nodata;
+export default NoData;

--- a/src/temp/SearchListDummy.ts
+++ b/src/temp/SearchListDummy.ts
@@ -1,0 +1,37 @@
+import { DetailPageProps } from '@pages/search/[id]';
+
+export const dummys: DetailPageProps[] = [
+  {
+    id: 1,
+    image: `https://c2.poing.co.kr/place/image/thumbnail/MjAyMTA5/163100066261371856c2830.jpg`,
+    types: ['강남구', '하이엔드'],
+    name: `스시조`,
+    desc: `오마카세 경력 25년의 셰프와 산지직송
+제철 식자재의 정성이 담긴 요리`,
+    location: '서울특별시 강남구 어쩌고 저쩌구동 저쩌구 상가 A동 2342124호',
+    tel: '02) 12345-67890',
+    price: '디너 300,000 ~',
+  },
+  {
+    id: 2,
+    image: `https://c2.poing.co.kr/place/image/service/MjAyMTA5/163101073861373fb28a0a2.jpg`,
+    types: ['강남구', '하이엔드'],
+    name: `스시조어진`,
+    desc: `오마카세 경력 25년의 셰프와 산지직송
+제철 식자재의 정성이 담긴 요리`,
+    location: '서울특별시 강남구 어쩌고 저쩌구동 저쩌구 상가 B동 24호',
+    tel: '02) 010-67890',
+    price: '디너 250,000 ~',
+  },
+  {
+    id: 3,
+    image: `https://c2.poing.co.kr/place/image/service/MjAyMTA5/1631000742613718a614ac5.jpg`,
+    types: ['은평구', '하이엔드'],
+    name: `조어진스시`,
+    desc: `오마카세 경력 25년의 셰프와 산지직송
+제철 식자재의 정성이 담긴 요리`,
+    location: '서울특별시 은평구 저기 어딘가',
+    tel: '02) 15-690',
+    price: '디너 1,300,000 ~',
+  },
+];


### PR DESCRIPTION
## :bookmark_tabs: 제목

동적 라우팅이 적용된 매장 상세페이지 기본 마크업 작성

> 배포페이지 : https://omo-deployment.vercel.app/search

![ababab](https://user-images.githubusercontent.com/48883344/134803131-0527bf31-3077-4830-adae-c838d2276b18.PNG)

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 매장 상세페이지 관련 UI 구조 작성
- [x] 더미 데이터 관련 외부 파일로 분리 후 import 하여 UI 작성
- [x] StoreDescription 컴포넌트 작성

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 버튼은 추후 아예 공용 컴포넌트로 분리하는게 좋을 거 같습니다~
- 지금 버튼 관련 클릭 이벤트는 기능 연동 안 되어있음!
