### PR TITLE
feature/OMO-48/검색페이지 창 작성

### DIFF
--- a/src/components/Header/HeaderInput.tsx
+++ b/src/components/Header/HeaderInput.tsx
@@ -1,0 +1,42 @@
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+import Prev from '@assets/prev.svg';
+
+import * as S from './styles';
+
+interface HeaderInputProps {
+  placeholder: string;
+  serachHandler: (text: string) => void;
+}
+
+const InputHeader = ({ placeholder, serachHandler }: HeaderInputProps) => {
+  const router = useRouter();
+  const [text, setText] = useState('');
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setText(value);
+  };
+
+  const handleOnSubmit = () => {
+    serachHandler(text);
+  };
+
+  return (
+    <S.Header className="container">
+      <S.PrevButton onClick={() => router.back()}>
+        <Prev />
+      </S.PrevButton>
+      <S.Input
+        type="text"
+        value={text}
+        onChange={(e) => handleOnChange(e)}
+        placeholder={placeholder}
+      />
+      <S.SearchButton onClick={handleOnSubmit}>검색</S.SearchButton>
+    </S.Header>
+  );
+};
+
+export default InputHeader;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './Header';
+export { default as HeaderInput } from './HeaderInput';

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -25,3 +25,23 @@ export const Title = styled.h1`
   font-weight: bold;
   font-family: 'Noto Sans KR', sans-serif;
 `;
+
+export const Input = styled.input`
+  width: 100%;
+  font-size: 14px;
+  font-weight: 400;
+  font-family: 'Noto Sans KR', sans-serif;
+  border: none;
+  outline: none;
+  padding: 0 40px;
+`;
+
+export const SearchButton = styled(PrevButton)`
+  left: unset;
+  right: 21px;
+  margin: 0;
+  font-weight: bold;
+  font-family: 'Noto Sans KR', sans-serif;
+  font-size: 14px;
+  line-height: 140%;
+`;

--- a/src/components/StoreDescription/styles.ts
+++ b/src/components/StoreDescription/styles.ts
@@ -50,6 +50,7 @@ export const StoreDescription = styled.div`
 
   .hashtag-wrapper {
     display: flex;
+    flex-wrap: wrap;
   }
 
   .button-wrapper {
@@ -60,10 +61,13 @@ export const HashTag = styled.span`
   border-radius: 20px;
   padding: 6px 15px;
   background-color: #f0f0f0;
-
-  & + & {
-    margin-left: 10px;
-  }
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 140%;
+  font-family: 'Noto Sans KR', sans-serif;
+  color: #444;
+  margin-right: 10px;
+  margin-bottom: 10px;
 `;
 
 export const Button = styled.button<ButtonProps>`

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,5 +1,6 @@
 // 기본 찾기 페이지
 
+import Link from 'next/link';
 import styled from 'styled-components';
 
 import Layout from '@components/Layout';
@@ -10,9 +11,13 @@ const Search = () => {
   return (
     <Layout title="오마카세 찾기">
       <SearchPage className="container">
-        <SearchBar>
-          <input type="text" placeholder="위치 / 가게명을 검색해보세요." />
-        </SearchBar>
+        <Link href="/search/searching" passHref>
+          <a>
+            <SearchBar>
+              <span>위치 / 가게명을 검색해보세요.</span>
+            </SearchBar>
+          </a>
+        </Link>
 
         {dummys.map((dummy) => (
           <StoreDisplay
@@ -31,7 +36,11 @@ const Search = () => {
 
 export default Search;
 
-const SearchPage = styled.section``;
+const SearchPage = styled.section`
+  a {
+    text-decoration: none;
+  }
+`;
 
 const SearchBar = styled.div`
   display: flex;
@@ -40,10 +49,10 @@ const SearchBar = styled.div`
   padding: 10px 24px;
   margin-bottom: 1rem;
 
-  input {
+  span {
     ${({ theme }) => theme.fonts.regular}
-    border: none;
-    outline: none;
     width: 100%;
+    color: #989898;
+    padding: 5px 0;
   }
 `;

--- a/src/pages/search/searching.tsx
+++ b/src/pages/search/searching.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+import { HeaderInput } from '@components/Header';
+import { HashTag } from '@components/StoreDescription/styles';
+import StoreDisplay from '@components/StoreDisplay';
+import { dummys } from '@temp/SearchListDummy';
+
+import { DetailPageProps } from './[id]';
+
+const Searching = () => {
+  const [stores, setStores] = useState<DetailPageProps[]>([]);
+
+  const tempGetStoresByText = (text: string) => {
+    const stores = dummys.filter((dummy) => dummy.name.includes(text));
+    setStores(stores);
+  };
+
+  return (
+    <SearchingPage>
+      <HeaderInput placeholder="위치/가게명을 검색해주세요." serachHandler={tempGetStoresByText} />
+      <SearchingData className="container">
+        {stores?.length ? (
+          stores.map((store) => (
+            <StoreDisplay
+              key={store.id}
+              id={store.id}
+              types={store.types}
+              image={store.image}
+              name={store.name}
+              desc={store.desc}
+            />
+          ))
+        ) : (
+          <RecentSeachedTexts>
+            <HashTag>#은평구</HashTag>
+            <HashTag>#강남구</HashTag>
+            <HashTag>#강서구</HashTag>
+            <HashTag>#강동구</HashTag>
+            <HashTag>#하이엔드</HashTag>
+            <HashTag>#미들</HashTag>
+            <HashTag>#라이트</HashTag>
+          </RecentSeachedTexts>
+        )}
+      </SearchingData>
+    </SearchingPage>
+  );
+};
+
+export default Searching;
+
+const SearchingPage = styled.section`
+  display: flex;
+  flex-direction: column;
+`;
+
+const SearchingData = styled.div`
+  flex: 1;
+  overflow: auto;
+`;
+
+const RecentSeachedTexts = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`;


### PR DESCRIPTION
## :bookmark_tabs: 제목

검색페이지 내 검색창 기본 UI 마크업 구조 작성 및 간단한 검색 로직 기능 더미데이터를 활용해 구현

| img1 | img2 |
|:---:|:---:|
| ![s1](https://user-images.githubusercontent.com/48883344/134861440-27cae714-dd60-4e00-81ff-264fe30b485a.PNG) | ![s2](https://user-images.githubusercontent.com/48883344/134861445-680121e2-2556-4023-8aea-5b00e32e858e.PNG) |



## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 검색창 페이지 기본 마크업 구조 작성
- [x] 실제 검색 로직 기능은 더미데이터를 활용하여 구현 (별도 API 호출 연동 X)
- [x] 공용 Header 컴포넌트 세분화 (기존 Header / 검색을 위한 HeaderInput)

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 기존 검색페이지에 있던 input을 링크로 변경하고, 클릭 시 검색창으로 이동하게끔 변경했습니다. 이 부분을 저희가 회의했을 땐 별도 페이지로 두지말고 내부에서 바로 전환되게끔 하는 방식을 이야기 했었는데 디자인 상 이 부분을 적용하기에 변경 사항이 많이 생기는 것 같아 일단 와이어프레임 시안대로 동일하게 작성했습니다. 이 부분은 추후 디자인 팀분들이랑 같이 이야기 해봐야 할 거 같아요~
- 검색 로직은 아직 API 전달받은게 없으므로 그냥 더미데이터 활용해서 처리했습니다. 추후 갈아엎어야 함!
- 데이타 없을 시 출력할 화면은 아직 안 만들었습니다!

> 임시배포: https://omo-deployment.vercel.app/search
