### PR TITLE
feature/OMO-48/검색결과 없을 시 스크린 마크업 작성

### DIFF
--- a/src/components/Header/HeaderInput.tsx
+++ b/src/components/Header/HeaderInput.tsx
@@ -19,6 +19,10 @@ const InputHeader = ({ placeholder, serachHandler }: HeaderInputProps) => {
     setText(value);
   };
 
+  const clearText = () => {
+    setText('');
+  };
+
   const handleOnSubmit = () => {
     serachHandler(text);
   };
@@ -34,7 +38,11 @@ const InputHeader = ({ placeholder, serachHandler }: HeaderInputProps) => {
         onChange={(e) => handleOnChange(e)}
         placeholder={placeholder}
       />
-      <S.SearchButton onClick={handleOnSubmit}>검색</S.SearchButton>
+      {text ? (
+        <S.SearchButton onClick={handleOnSubmit}>검색</S.SearchButton>
+      ) : (
+        <S.SearchButton onClick={clearText}>검색어 초기화</S.SearchButton>
+      )}
     </S.Header>
   );
 };

--- a/src/components/SearchNoData/SearchNoData.tsx
+++ b/src/components/SearchNoData/SearchNoData.tsx
@@ -1,0 +1,30 @@
+import Button from '@components/Shared/Button';
+import { HashTag } from '@components/StoreDescription/styles';
+
+import * as S from './styles';
+
+const SearchNoData = () => {
+  return (
+    <S.NoData>
+      <div className="guide-message-wrapper">
+        <p className="guide-message">검색결과가 없어요!</p>
+        <p className="guide-message">혹시, 이런 검색어는 어떠세요?</p>
+      </div>
+
+      <div className="hashtag-wrapper">
+        <HashTag>#강남구</HashTag>
+        <HashTag>#강동구</HashTag>
+        <HashTag>#미들</HashTag>
+      </div>
+
+      <div className="guide-message-wrapper">
+        <p className="guide-message">원하는 오마카세를 찾지 못하셨나요?</p>
+        <p className="guide-message">직접 제보해주세요!</p>
+      </div>
+
+      <Button clickListener={() => alert('제보')} text="오마카세 제보하기" bgColor="#C9C9C9" />
+    </S.NoData>
+  );
+};
+
+export default SearchNoData;

--- a/src/components/SearchNoData/SearchNoData.tsx
+++ b/src/components/SearchNoData/SearchNoData.tsx
@@ -1,9 +1,18 @@
+import { useState } from 'react';
+
 import Button from '@components/Shared/Button';
+import { SuggestModal } from '@components/Shared/Modal';
 import { HashTag } from '@components/StoreDescription/styles';
 
 import * as S from './styles';
 
 const SearchNoData = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const toggleModal = () => {
+    setIsModalOpen((prev) => !prev);
+  };
+
   return (
     <S.NoData>
       <div className="guide-message-wrapper">
@@ -22,7 +31,8 @@ const SearchNoData = () => {
         <p className="guide-message">직접 제보해주세요!</p>
       </div>
 
-      <Button clickListener={() => alert('제보')} text="오마카세 제보하기" bgColor="#C9C9C9" />
+      <Button clickListener={toggleModal} text="오마카세 제보하기" bgColor="#C9C9C9" />
+      {isModalOpen && <SuggestModal toggleModal={toggleModal} />}
     </S.NoData>
   );
 };

--- a/src/components/SearchNoData/index.tsx
+++ b/src/components/SearchNoData/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './SearchNoData';

--- a/src/components/SearchNoData/styles.ts
+++ b/src/components/SearchNoData/styles.ts
@@ -16,6 +16,8 @@ export const NoData = styled.div`
   }
 
   .hashtag-wrapper {
+    display: flex;
+    flex-wrap: wrap;
     margin: auto;
     margin-top: 1rem;
     margin-bottom: 4rem;

--- a/src/components/SearchNoData/styles.ts
+++ b/src/components/SearchNoData/styles.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+export const NoData = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+
+  .guide-message-wrapper {
+    font-size: 14px;
+    font-family: 'Noto Sans KR', sans-serif;
+    line-height: 140%;
+    font-weight: 400;
+    text-align: center;
+    margin: 1rem 0;
+  }
+
+  .hashtag-wrapper {
+    margin: auto;
+    margin-top: 1rem;
+    margin-bottom: 4rem;
+  }
+`;

--- a/src/components/Shared/Button/Button.tsx
+++ b/src/components/Shared/Button/Button.tsx
@@ -1,0 +1,17 @@
+import * as S from './styles';
+
+interface ButtonProps {
+  text: string;
+  bgColor?: string;
+  clickListener: () => void;
+}
+
+const Button = ({ text, bgColor, clickListener }: ButtonProps) => {
+  return (
+    <S.Button onClick={clickListener} bgColor={bgColor ? bgColor : ''}>
+      {text}
+    </S.Button>
+  );
+};
+
+export default Button;

--- a/src/components/Shared/Button/index.tsx
+++ b/src/components/Shared/Button/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Button';

--- a/src/components/Shared/Button/styles.ts
+++ b/src/components/Shared/Button/styles.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+interface ButtonProps {
+  bgColor?: string;
+}
+
+export const Button = styled.button<ButtonProps>`
+  width: 100%;
+  padding: 16px;
+  color: #4b4b4b;
+  outline: none;
+  border: none;
+  border-radius: 12px;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 140%;
+  font-family: 'Noto Sans KR', sans-serif;
+  background-color: ${({ bgColor }) => (bgColor ? bgColor : 'transparent')};
+  border: ${({ bgColor }) => (bgColor ? 'none' : '1px solid #9e9e9e')};
+
+  & + & {
+    margin-top: 14px;
+  }
+`;

--- a/src/components/Shared/Modal/SuggestModal.tsx
+++ b/src/components/Shared/Modal/SuggestModal.tsx
@@ -1,0 +1,49 @@
+import Button from '@components/Shared/Button';
+import { HashTag } from '@components/StoreDescription/styles';
+
+import * as S from './styles';
+
+interface SuggestModalProps {
+  toggleModal: (isOpen: boolean) => void;
+}
+
+const SuggestModal = ({ toggleModal }: SuggestModalProps) => {
+  return (
+    <S.ModalWrapper>
+      <S.ModalBox>
+        <S.SuggestModal>
+          <div className="guide-message-wrapper">
+            <p className="guide-message">원하는 오마카세를 찾지 못하셨나요?</p>
+            <p className="guide-message">직접 제보해주시면 확인 후 오모에 추가해둘게요!</p>
+          </div>
+
+          <S.LocationWrapper>
+            <div className="sub-title">지역</div>
+            <div className="hashtag-wrapper">
+              <HashTag>#강남구</HashTag>
+              <HashTag>#강동구</HashTag>
+              <HashTag>#어쩌구</HashTag>
+              <HashTag>#모르겠어요</HashTag>
+            </div>
+          </S.LocationWrapper>
+
+          <S.InputWrapper>
+            <label className="sub-title">오마카세이름</label>
+            <input type="text" />
+          </S.InputWrapper>
+
+          <Button
+            clickListener={() => {
+              alert('제보완료');
+              toggleModal(false);
+            }}
+            text="제보완료"
+            bgColor="#c9c9c9"
+          />
+        </S.SuggestModal>
+      </S.ModalBox>
+    </S.ModalWrapper>
+  );
+};
+
+export default SuggestModal;

--- a/src/components/Shared/Modal/index.tsx
+++ b/src/components/Shared/Modal/index.tsx
@@ -1,0 +1,1 @@
+export { default as SuggestModal } from './SuggestModal';

--- a/src/components/Shared/Modal/styles.ts
+++ b/src/components/Shared/Modal/styles.ts
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+
+export const ModalWrapper = styled.div`
+  background-color: rgba(0, 0, 0, 0.3);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+`;
+
+export const ModalBox = styled.div`
+  background-color: #fff;
+  width: 100%;
+  padding: 16px;
+  margin: 0 21px;
+`;
+
+export const SuggestModal = styled.section`
+  display: flex;
+  flex-direction: column;
+
+  .sub-title {
+    font-size: 14px;
+    font-family: 'Noto Sans KR', sans-serif;
+    line-height: 140%;
+    font-weight: 400;
+  }
+`;
+
+export const LocationWrapper = styled.article`
+  display: flex;
+  flex-direction: column;
+  margin: 1rem 0;
+
+  .hashtag-wrapper {
+    margin-top: 10px !important;
+    margin-bottom: 0 !important;
+  }
+`;
+
+export const InputWrapper = styled.article`
+  display: flex;
+  flex-direction: column;
+
+  input {
+    border: none;
+    outline: none;
+    border-bottom: 1px solid #e2e2e2;
+    padding-bottom: 5px;
+    margin-top: 1rem;
+    margin-bottom: 4rem;
+  }
+`;

--- a/src/components/StoreDescription/StoreDescription.tsx
+++ b/src/components/StoreDescription/StoreDescription.tsx
@@ -1,3 +1,4 @@
+import Button from '@components/Shared/Button';
 import { DetailPageProps } from '@pages/search/[id]';
 
 import * as S from './styles';
@@ -32,10 +33,8 @@ const StoreDescription = ({ store }: StoreDescriptionProps) => {
       </div>
 
       <div className="button-wrapper">
-        <S.Button onClick={() => alert('문의중...')}>예약 문의 하기</S.Button>
-        <S.Button onClick={() => alert('깨는중...')} bgColor="#c9c9c9">
-          이 가게 도장깨기
-        </S.Button>
+        <Button clickListener={() => alert('문의중')} text="예약 문의 하기" />
+        <Button clickListener={() => alert('문의중')} bgColor="#c9c9c9" text="이 가게 도장깨기" />
       </div>
     </S.StoreDescription>
   );

--- a/src/pages/search/nodata.tsx
+++ b/src/pages/search/nodata.tsx
@@ -1,7 +1,0 @@
-// 아무 데이터가 없는 경우
-
-const NoData = () => {
-  return <div>노 데이타</div>;
-};
-
-export default NoData;

--- a/src/pages/search/searching.tsx
+++ b/src/pages/search/searching.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { HeaderInput } from '@components/Header';
+import SearchNoData from '@components/SearchNoData';
 import { HashTag } from '@components/StoreDescription/styles';
 import StoreDisplay from '@components/StoreDisplay';
 import { dummys } from '@temp/SearchListDummy';
@@ -9,10 +10,12 @@ import { dummys } from '@temp/SearchListDummy';
 import { DetailPageProps } from './[id]';
 
 const Searching = () => {
+  const [isSearched, setIsSearched] = useState<boolean>(false);
   const [stores, setStores] = useState<DetailPageProps[]>([]);
 
   const tempGetStoresByText = (text: string) => {
     const stores = dummys.filter((dummy) => dummy.name.includes(text));
+    setIsSearched(true);
     setStores(stores);
   };
 
@@ -31,6 +34,8 @@ const Searching = () => {
               desc={store.desc}
             />
           ))
+        ) : isSearched ? (
+          <SearchNoData />
         ) : (
           <RecentSeachedTexts>
             <HashTag>#은평구</HashTag>
@@ -52,6 +57,7 @@ export default Searching;
 const SearchingPage = styled.section`
   display: flex;
   flex-direction: column;
+  height: 100vh;
 `;
 
 const SearchingData = styled.div`


### PR DESCRIPTION
## :bookmark_tabs: 제목

검색 결과 존재하지 않을 경우 페이지 및 모달 창 작성

https://user-images.githubusercontent.com/48883344/135385005-55b27349-1a9c-4133-b21f-2a0fd20a34cf.mp4

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] Test Code를 작성하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 검색결과 존재하지 않을 경우 페이지 작성
- [x] 제보하기 관련 모달창 작성

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 검색어 초기화 관련 로직 매우 간단하게 적용했는데 조금 더 세부적으로 살펴봐야 할 거 같슴당
- 모달창에 따로 모달창을 끄는 버튼이 없어서 (디자인상) 외곽을 클릭했을 때 꺼지도록 해야할 거 같슴당
- 모달/버튼 이런 친구들은 `components/Shared` 폴더 밑으로 정리해서 공용으로 따로 구분하고 있는데 막상 나눠보니 `Shared` 이름이 좀 적합하지 않은 것 같기도..!?
