### PR TITLE
feature/OMO-70/인증페이지 바텀 액션 시트 레이아웃 작성

### DIFF
--- a/src/components/Certification/LocationChecker.tsx
+++ b/src/components/Certification/LocationChecker.tsx
@@ -7,18 +7,22 @@ type LocationCheckerProps = {
   image: string;
   location: string;
   name: string;
+  handleClickOnReselectLocation: () => void;
 };
 
-const LocationChecker = ({ image, location, name }: LocationCheckerProps) => {
-  const handleClickOnReselectStore = () => alert('밑에서 부와앙');
-
+const LocationChecker = ({
+  image,
+  location,
+  name,
+  handleClickOnReselectLocation,
+}: LocationCheckerProps) => {
   return (
     <S.LocationChecker>
       <S.TitleWrapper>
         <S.Title>
           이 <strong>장소</strong>가 맞나요?
         </S.Title>
-        <S.ReselectBtn onClick={handleClickOnReselectStore}>다시 선택하기</S.ReselectBtn>
+        <S.ReselectBtn onClick={handleClickOnReselectLocation}>다시 선택하기</S.ReselectBtn>
       </S.TitleWrapper>
 
       <S.SelectedStorePreviewWrapper>

--- a/src/components/Certification/LocationChecker.tsx
+++ b/src/components/Certification/LocationChecker.tsx
@@ -1,18 +1,22 @@
 import Image from 'next/image';
 import React from 'react';
 
+import { DetailPageProps } from '@pages/search/[id]';
+
 import * as S from './styles';
 
 type LocationCheckerProps = {
+  store?: DetailPageProps;
   image: string;
-  location: string;
+  address: string;
   name: string;
   handleClickOnReselectLocation: () => void;
 };
 
 const LocationChecker = ({
+  store,
   image,
-  location,
+  address,
   name,
   handleClickOnReselectLocation,
 }: LocationCheckerProps) => {
@@ -27,11 +31,17 @@ const LocationChecker = ({
 
       <S.SelectedStorePreviewWrapper>
         <S.SelectedStoreInfo>
-          <h1 className="title">{name}</h1>
-          <p className="location">{location}</p>
+          <h1 className="title">{store?.name ?? name}</h1>
+          <p className="address">{store?.address ?? address}</p>
         </S.SelectedStoreInfo>
         <S.SelectedStoreImageWrapper>
-          <Image src={image} alt="매장 프리뷰 이미지" layout="fixed" width={200} height={160} />
+          <Image
+            src={store?.image_url ?? image}
+            alt="매장 프리뷰 이미지"
+            layout="fixed"
+            width={200}
+            height={160}
+          />
         </S.SelectedStoreImageWrapper>
       </S.SelectedStorePreviewWrapper>
     </S.LocationChecker>

--- a/src/components/Certification/SearchBottomActionSheet.tsx
+++ b/src/components/Certification/SearchBottomActionSheet.tsx
@@ -4,11 +4,13 @@ import React, { useState } from 'react';
 import CloseIcon from '@assets/close.svg';
 import SearchIcon from '@assets/search.svg';
 import { StoreDisplayList } from '@components/StoreDisplay';
+import PreventLinkAction from '@lib/preventLinkAction';
 import { DetailPageProps } from '@pages/search/[id]';
 
 import * as S from './styles';
 
 type SearchBottomActionSheetProps = {
+  setStore: React.Dispatch<React.SetStateAction<DetailPageProps | undefined>>;
   handleClickOnReselectLocation: () => void;
 };
 
@@ -19,6 +21,7 @@ type Omakases = {
 
 const SearchBottomActionSheet = ({
   handleClickOnReselectLocation,
+  setStore,
 }: SearchBottomActionSheetProps) => {
   const [searchWord, setSearchWord] = useState('');
   const [stores, setStores] = useState<DetailPageProps[]>([]);
@@ -39,11 +42,22 @@ const SearchBottomActionSheet = ({
     setStores(searchingOmakases);
   };
 
+  const handleClickOnCloseBtn = () => {
+    setSearchWord('');
+    setStores([]);
+    handleClickOnReselectLocation();
+  };
+
+  const handleClickOnNewStoreDisplay = (selectedStore: DetailPageProps) => {
+    setStore(selectedStore);
+    handleClickOnCloseBtn();
+  };
+
   return (
     <S.SearchBottomActionSheet>
       <S.TitleWrapper>
         <S.Title>장소변경</S.Title>
-        <CloseIcon onClick={handleClickOnReselectLocation} />
+        <CloseIcon onClick={handleClickOnCloseBtn} />
       </S.TitleWrapper>
 
       <S.SearchInputBar>
@@ -56,15 +70,19 @@ const SearchBottomActionSheet = ({
           <S.SearchNoData>데이터가 없을땐 무엇을 보여주어야 하지?</S.SearchNoData>
         ) : (
           stores.map((store) => (
-            <StoreDisplayList
+            <PreventLinkAction
               key={store.id}
-              id={store.id}
-              image_url={store.image_url}
-              level={store.level}
-              county={store.county}
-              name={store.name}
-              address={store.address}
-            />
+              onClickHandler={() => handleClickOnNewStoreDisplay(store)}
+            >
+              <StoreDisplayList
+                id={store.id}
+                image_url={store.image_url}
+                level={store.level}
+                county={store.county}
+                name={store.name}
+                address={store.address}
+              />
+            </PreventLinkAction>
           ))
         )}
       </S.SearchResults>

--- a/src/components/Certification/SearchBottomActionSheet.tsx
+++ b/src/components/Certification/SearchBottomActionSheet.tsx
@@ -1,0 +1,75 @@
+import axios from 'axios';
+import React, { useState } from 'react';
+
+import CloseIcon from '@assets/close.svg';
+import SearchIcon from '@assets/search.svg';
+import { StoreDisplayList } from '@components/StoreDisplay';
+import { DetailPageProps } from '@pages/search/[id]';
+
+import * as S from './styles';
+
+type SearchBottomActionSheetProps = {
+  handleClickOnReselectLocation: () => void;
+};
+
+type Omakases = {
+  total_elements: number;
+  omakases: DetailPageProps[];
+};
+
+const SearchBottomActionSheet = ({
+  handleClickOnReselectLocation,
+}: SearchBottomActionSheetProps) => {
+  const [searchWord, setSearchWord] = useState('');
+  const [stores, setStores] = useState<DetailPageProps[]>([]);
+
+  const handleChangeOnInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { value },
+    } = e;
+    setSearchWord(value);
+  };
+
+  const handleClickOnSearchIcon = async (keyword: string) => {
+    const {
+      data: { omakases },
+    } = await axios.get<Omakases>(`/api/omakases`);
+
+    const searchingOmakases = omakases.filter((omakase) => omakase.name.includes(keyword));
+    setStores(searchingOmakases);
+  };
+
+  return (
+    <S.SearchBottomActionSheet>
+      <S.TitleWrapper>
+        <S.Title>장소변경</S.Title>
+        <CloseIcon onClick={handleClickOnReselectLocation} />
+      </S.TitleWrapper>
+
+      <S.SearchInputBar>
+        <input value={searchWord} onChange={handleChangeOnInput} />
+        <SearchIcon onClick={() => handleClickOnSearchIcon(searchWord)} />
+      </S.SearchInputBar>
+
+      <S.SearchResults>
+        {!stores.length ? (
+          <S.SearchNoData>데이터가 없을땐 무엇을 보여주어야 하지?</S.SearchNoData>
+        ) : (
+          stores.map((store) => (
+            <StoreDisplayList
+              key={store.id}
+              id={store.id}
+              image_url={store.image_url}
+              level={store.level}
+              county={store.county}
+              name={store.name}
+              address={store.address}
+            />
+          ))
+        )}
+      </S.SearchResults>
+    </S.SearchBottomActionSheet>
+  );
+};
+
+export default SearchBottomActionSheet;

--- a/src/components/Certification/index.ts
+++ b/src/components/Certification/index.ts
@@ -1,2 +1,3 @@
 export { default as LocationChecker } from './LocationChecker';
 export { default as ReceiptChecker } from './ReceiptChecker';
+export { default as SearchBottomActionSheet } from './SearchBottomActionSheet';

--- a/src/components/Certification/styles.tsx
+++ b/src/components/Certification/styles.tsx
@@ -50,7 +50,7 @@ export const SelectedStoreInfo = styled.div`
     margin-top: 6px;
     margin-bottom: 8px;
   }
-  .location {
+  .address {
     ${({ theme }) => theme.fonts.contents2};
     color: ${({ theme }) => theme.colors.black500};
     overflow: hidden;

--- a/src/components/Certification/styles.tsx
+++ b/src/components/Certification/styles.tsx
@@ -144,3 +144,49 @@ export const ToggleDescription = styled.div`
     font-weight: bold;
   }
 `;
+
+export const SearchBottomActionSheet = styled.div`
+  position: absolute;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  background-color: #fff;
+  border-radius: 10px 10px 0 0;
+  width: 100%;
+  height: 87vh;
+  padding: 20px;
+  box-sizing: border-box;
+  transform: translateY(100%);
+  transition: transform 0.35s;
+  z-index: 100;
+`;
+
+export const SearchInputBar = styled.div`
+  margin: 20px 0;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  box-sizing: border-box;
+  align-items: center;
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.colors.black100};
+  padding: 12px 16px;
+
+  input {
+    flex: 1;
+    margin-right: 15px;
+    border: none;
+    outline: none;
+    background-color: transparent;
+    ${({ theme }) => theme.fonts.contents3};
+  }
+`;
+
+export const SearchResults = styled.div`
+  flex: 1;
+  overflow-y: scroll;
+`;
+
+export const SearchNoData = styled.div`
+  margin: 50% 25%;
+`;

--- a/src/lib/PreventLinkAction.tsx
+++ b/src/lib/PreventLinkAction.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface PreventLinkActionProps {
+  children: React.ReactNode;
+  onClickHandler?: () => void;
+}
+
+const PreventLinkAction = ({ children, onClickHandler }: PreventLinkActionProps) => {
+  const preventLinking = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    e.preventDefault();
+    onClickHandler?.();
+
+    return;
+  };
+  return (
+    <PreventEventPropagation onClickCapture={(e) => preventLinking(e)}>
+      {children}
+    </PreventEventPropagation>
+  );
+};
+
+export default PreventLinkAction;
+
+const PreventEventPropagation = styled.div`
+  z-index: 100;
+`;

--- a/src/pages/certification/index.tsx
+++ b/src/pages/certification/index.tsx
@@ -1,30 +1,41 @@
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import { LocationChecker, ReceiptChecker } from '@components/Certification';
+import { SearchBottomActionSheet as StyledSearchBottomActionSheet } from '@/components/Certification/styles';
+import {
+  LocationChecker,
+  ReceiptChecker,
+  SearchBottomActionSheet,
+} from '@components/Certification';
 import Header from '@components/Header';
 import Button from '@components/Shared/Button';
 import { CertificationModal } from '@components/Shared/Modal';
 
 const Certification = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isActionSheetActive, setIsActionSheetActive] = useState(false);
   const {
     query: { blobUrl, image, location, name },
   } = useRouter();
+
+  const handleClickOnReselectLocation = () => {
+    setIsActionSheetActive((prev) => !prev);
+  };
 
   useEffect(() => {
     return () => URL.revokeObjectURL(blobUrl as string);
   }, [blobUrl]);
 
   return (
-    <CertificationPage>
+    <CertificationPage isActionSheetActive={isActionSheetActive}>
       <Header title="인증확인" />
       <CertificationMain className="container">
         <LocationChecker
           image={image as string}
           location={location as string}
           name={name as string}
+          handleClickOnReselectLocation={handleClickOnReselectLocation}
         />
 
         <ReceiptChecker blobUrl={blobUrl as string} />
@@ -36,17 +47,39 @@ const Certification = () => {
           text="도장깨기 접수하기"
         />
       </CertificationMain>
+
       {isModalOpen && <CertificationModal name={name as string} />}
+      <SearchBottomActionSheet handleClickOnReselectLocation={handleClickOnReselectLocation} />
     </CertificationPage>
   );
 };
 
 export default Certification;
 
-const CertificationPage = styled.section`
+const CertificationPage = styled.section<{ isActionSheetActive: boolean }>`
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100vh;
+
+  ${({ isActionSheetActive }) =>
+    isActionSheetActive &&
+    css`
+      ${StyledSearchBottomActionSheet} {
+        transform: translateY(0);
+      }
+
+      &::after {
+        content: '';
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        top: 0;
+        left: 0;
+        background-color: rgba(0, 0, 0, 0.4);
+        z-index: 10;
+      }
+    `}
 `;
 
 const CertificationMain = styled.article`

--- a/src/pages/certification/index.tsx
+++ b/src/pages/certification/index.tsx
@@ -11,8 +11,10 @@ import {
 import Header from '@components/Header';
 import Button from '@components/Shared/Button';
 import { CertificationModal } from '@components/Shared/Modal';
+import { DetailPageProps } from '@pages/search/[id]';
 
 const Certification = () => {
+  const [store, setStore] = useState<DetailPageProps>();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isActionSheetActive, setIsActionSheetActive] = useState(false);
   const {
@@ -32,8 +34,9 @@ const Certification = () => {
       <Header title="인증확인" />
       <CertificationMain className="container">
         <LocationChecker
+          store={store}
           image={image as string}
-          location={location as string}
+          address={location as string}
           name={name as string}
           handleClickOnReselectLocation={handleClickOnReselectLocation}
         />
@@ -49,7 +52,10 @@ const Certification = () => {
       </CertificationMain>
 
       {isModalOpen && <CertificationModal name={name as string} />}
-      <SearchBottomActionSheet handleClickOnReselectLocation={handleClickOnReselectLocation} />
+      <SearchBottomActionSheet
+        setStore={setStore}
+        handleClickOnReselectLocation={handleClickOnReselectLocation}
+      />
     </CertificationPage>
   );
 };

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -50,7 +50,7 @@ const Search = () => {
       const { omakases } = res.data;
       setTempStores(omakases.filter((omakase) => omakase.level === tab));
     });
-  }, [tab, tempStores]);
+  }, [tab]);
 
   const toggleModal = () => {
     setIsOpenModal((prev) => !prev);


### PR DESCRIPTION
## :bookmark_tabs: 제목

장소 재선택을 위한 바텀 액션 시트를 작성했습니다!


https://user-images.githubusercontent.com/48883344/140955777-c544cfb1-1936-4a5a-a9b1-126f1cf6f825.mp4

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 바텀 액션 시트 레이아웃 작성
- [x] 관련 api 호출 및 상태관리

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- ~~선택 시 인증확인 페이지에서 선택된 가게정보로 바뀌도록 로직 구현해야 함 (현재는 상세페이지로 이동)~~
- 추후 스와이프 기능이 구현되면 적용
- 데이터 없을때 보여줄 디자인이 필요할듯
- 해당 작업은 나의 수면권 보장을 위해 내일 하겠슴
