### PR TITLE
feature/omo-100/랭커목록api, logout api 연동

### DIFF
--- a/src/components/Shared/RankingCard/RankingCard.tsx
+++ b/src/components/Shared/RankingCard/RankingCard.tsx
@@ -3,29 +3,24 @@ import Image from 'next/image';
 import MessageBubble from '@assets/message-bubble.svg';
 import RightButton from '@assets/ranking-card-right-button.svg';
 import { RANK_SUFFIX, STAMP_AMOUNT_PREFIX, STAMP_AMOUNT_SUFFIX } from '@constants/shared';
+import { IRankerState } from '@recoil/rankerState';
 
 import * as S from './styles';
-
-interface IRankingCard {
-  rank: number;
-  nickname: string;
-  amount: number;
-}
 
 /**
  * @usage Home, Ranking Page
  */
-const RankingCard = ({ props }: { props: IRankingCard }) => {
-  const { rank, nickname, amount } = props;
-  const isRanker = [1, 2, 3].includes(rank);
+const RankingCard = ({ ranker }: { ranker: IRankerState }) => {
+  const { ranking, nickname, stampCount, profileUrl } = ranker;
+  const isRanker = [1, 2, 3].includes(ranking);
 
   return (
-    <S.RankingCardWrapper className="ranking-card" rank={rank}>
-      <S.ProfileArea rank={rank}>
+    <S.RankingCardWrapper className="ranking-card" rank={ranking}>
+      <S.ProfileArea rank={ranking}>
         {!isRanker && (
           <S.RankIndicator>
             <span>
-              {rank}
+              {ranking}
               {RANK_SUFFIX}
             </span>
           </S.RankIndicator>
@@ -35,11 +30,16 @@ const RankingCard = ({ props }: { props: IRankingCard }) => {
             <S.ProfileBubble>
               <MessageBubble />
               <span>
-                {rank}
+                {ranking}
                 {RANK_SUFFIX}
               </span>
             </S.ProfileBubble>
-            <Image src="/images/default-profile.png" width={55} height={55} alt="default-profile" />
+            <Image
+              src={profileUrl || '/images/default-profile.png'}
+              width={55}
+              height={55}
+              alt="default-profile"
+            />
           </>
         )}
       </S.ProfileArea>
@@ -48,7 +48,7 @@ const RankingCard = ({ props }: { props: IRankingCard }) => {
           {nickname}
           {!isRanker && (
             <span>
-              ({amount}
+              ({stampCount}
               {STAMP_AMOUNT_SUFFIX})
             </span>
           )}
@@ -56,7 +56,7 @@ const RankingCard = ({ props }: { props: IRankingCard }) => {
         {isRanker && (
           <S.StampAmount>
             {STAMP_AMOUNT_PREFIX}
-            {amount}
+            {stampCount}
             {STAMP_AMOUNT_SUFFIX}
           </S.StampAmount>
         )}
@@ -66,6 +66,14 @@ const RankingCard = ({ props }: { props: IRankingCard }) => {
       </S.RightButton>
     </S.RankingCardWrapper>
   );
+};
+
+RankingCard.defaultProps = {
+  ranker: {
+    ranking: 0,
+    nickname: '',
+    stampCount: 0,
+  },
 };
 
 export default RankingCard;

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -20,9 +20,19 @@ const Home = () => {
   const { contents: userValue } = useUserRecoilValue();
 
   const top3Rankers = [
-    { rank: 1, nickname: '오모마카세에대출', amount: 24 },
-    { rank: 2, nickname: '지니지니', amount: 14 },
-    { rank: 3, nickname: '오마카새우', amount: 8 },
+    {
+      ranking: 1,
+      nickname: '오모마카세에대출',
+      stampCount: 24,
+      profileUrl: null,
+    },
+    { ranking: 2, nickname: '지니지니', stampCount: 14, profileUrl: null },
+    {
+      ranking: 3,
+      nickname: '오마카새우',
+      stampCount: 8,
+      profileUrl: null,
+    },
   ];
 
   const setRefreshOnCookie = (refresh: string) => {
@@ -64,7 +74,7 @@ const Home = () => {
           <p>{'상위 랭킹 고수들의 오마카세 리스트를 참고해 보세요!'}</p>
           <RankingCardArea>
             {top3Rankers.map((props) => (
-              <RankingCard key={props.rank} props={props} />
+              <RankingCard key={props.ranking} ranker={props} />
             ))}
           </RankingCardArea>
         </RankingSection>

--- a/src/pages/mypage/settings.tsx
+++ b/src/pages/mypage/settings.tsx
@@ -11,7 +11,7 @@ import { showAlertModal } from '@utils/modal';
 const Settings = () => {
   const router = useRouter();
 
-  const handleLogOut = async () => {
+  const handleLogout = async () => {
     try {
       await requestLogout();
       //TODO: access token 날려야함
@@ -28,7 +28,7 @@ const Settings = () => {
   return (
     <>
       <Header title="개인정보 설정" />
-      <SettingSection onClick={handleLogOut}>
+      <SettingSection onClick={handleLogout}>
         <Link href="/" passHref>
           <a className="setting-link">로그아웃</a>
         </Link>

--- a/src/pages/mypage/settings.tsx
+++ b/src/pages/mypage/settings.tsx
@@ -14,8 +14,9 @@ const Settings = () => {
   const handleLogOut = async () => {
     try {
       await requestLogout();
+      //TODO: access token 날려야함
+      //TODO: 새로고침할 때도 token 정보를 유지하도록 수정해야함 -> localStorage?
       showAlertModal('로그아웃 되었습니다.');
-      router.push('/');
     } catch (error) {
       const { response } = error as requestError;
       if (!response) return showAlertModal(NETWORK_ERROR);
@@ -27,7 +28,11 @@ const Settings = () => {
   return (
     <>
       <Header title="개인정보 설정" />
-      <SettingSection onClick={handleLogOut}>로그아웃</SettingSection>
+      <SettingSection onClick={handleLogOut}>
+        <Link href="/" passHref>
+          <a className="setting-link">로그아웃</a>
+        </Link>
+      </SettingSection>
       <SettingSection>
         <Link href="/mypage/signout" passHref>
           <a className="setting-link">회원 탈퇴</a>
@@ -49,7 +54,7 @@ const Settings = () => {
 
 export default Settings;
 
-const SettingSection = styled.div`
+const SettingSection = styled.section`
   display: flex;
   align-items: center;
   font-size: 18px;

--- a/src/pages/mypage/settings.tsx
+++ b/src/pages/mypage/settings.tsx
@@ -1,14 +1,33 @@
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import styled from 'styled-components';
 
-// 개인정보 설정 페이지
+import { requestError } from '@@types/shared';
 import Header from '@components/Header';
+import { NETWORK_ERROR, UNKNOWN_ERROR } from '@constants/error';
+import { requestLogout } from '@request';
+import { showAlertModal } from '@utils/modal';
 
 const Settings = () => {
+  const router = useRouter();
+
+  const handleLogOut = async () => {
+    try {
+      await requestLogout();
+      showAlertModal('로그아웃 되었습니다.');
+      router.push('/');
+    } catch (error) {
+      const { response } = error as requestError;
+      if (!response) return showAlertModal(NETWORK_ERROR);
+
+      return showAlertModal(UNKNOWN_ERROR);
+    }
+  };
+
   return (
     <>
       <Header title="개인정보 설정" />
-      <SettingSection onClick={() => alert('로그아웃이 완료되었습니다.')}>로그아웃</SettingSection>
+      <SettingSection onClick={handleLogOut}>로그아웃</SettingSection>
       <SettingSection>
         <Link href="/mypage/signout" passHref>
           <a className="setting-link">회원 탈퇴</a>

--- a/src/pages/ranking/index.tsx
+++ b/src/pages/ranking/index.tsx
@@ -14,10 +14,11 @@ import { useUserRecoilValue } from '@recoil/userState';
 
 const Ranking = () => {
   const { contents: userValue } = useUserRecoilValue();
-  const { contents: rankerValue, state } = useRankerRecoilValue();
+  const { contents, state } = useRankerRecoilValue();
 
   const [isOpenModal, setIsOpenModal] = useState(false);
   const toggleModal = () => setIsOpenModal((prev) => !prev);
+  const rankerValue = contents as IRankerState[];
 
   const rankingList = [
     { rank: 1, nickname: '오마카세에대출땡', amount: 24 },
@@ -48,9 +49,9 @@ const Ranking = () => {
         <h1>전체랭킹</h1>
         <h2>랭킹은 매일 24시에 갱신됩니다.</h2>
         <Guidance className="guidance" onClick={toggleModal} />
-        {/* {rankerValue.map((ranker: IRankerState) => (
+        {rankerValue.map((ranker) => (
           <RankingCard ranker={ranker} key={ranker.ranking} />
-        ))} */}
+        ))}
       </RankingSection>
 
       <MyRankingSection>

--- a/src/pages/ranking/index.tsx
+++ b/src/pages/ranking/index.tsx
@@ -9,10 +9,12 @@ import { RankingNotifyModal } from '@components/Shared/Modal';
 import RankingCard from '@components/Shared/RankingCard';
 import { PIONEER_PHRASE } from '@constants/ranking';
 import { RANK_SUFFIX, STAMP_AMOUNT_SUFFIX } from '@constants/shared';
+import { IRankerState, useRankerRecoilValue } from '@recoil/rankerState';
 import { useUserRecoilValue } from '@recoil/userState';
 
 const Ranking = () => {
   const { contents: userValue } = useUserRecoilValue();
+  const { contents: rankerValue, state } = useRankerRecoilValue();
 
   const [isOpenModal, setIsOpenModal] = useState(false);
   const toggleModal = () => setIsOpenModal((prev) => !prev);
@@ -29,14 +31,15 @@ const Ranking = () => {
     { rank: 9, nickname: '오마카사위', amount: 3 },
     { rank: 10, nickname: '오마카사위', amount: 3 },
   ];
-
+  if (state === 'loading') return 'dd';
+  console.log(rankerValue);
   return (
     <Layout title="Ranking" noHeader>
       <OmakasePioneerSection>
         <h1>명예의 전당 ✨</h1>
         <OmakasePioneerWrapper>
           <p>{PIONEER_PHRASE}</p>
-          <p>{rankingList[0].nickname}</p>
+          <p>{rankerValue[0]?.nickname}</p>
           <BackgroundPattern className="pattern" />
           <Earth className="earth" />
         </OmakasePioneerWrapper>
@@ -45,9 +48,9 @@ const Ranking = () => {
         <h1>전체랭킹</h1>
         <h2>랭킹은 매일 24시에 갱신됩니다.</h2>
         <Guidance className="guidance" onClick={toggleModal} />
-        {rankingList.map((props) => (
-          <RankingCard props={props} key={props.rank} />
-        ))}
+        {/* {rankerValue.map((ranker: IRankerState) => (
+          <RankingCard ranker={ranker} key={ranker.ranking} />
+        ))} */}
       </RankingSection>
 
       <MyRankingSection>

--- a/src/pages/ranking/index.tsx
+++ b/src/pages/ranking/index.tsx
@@ -20,20 +20,8 @@ const Ranking = () => {
   const toggleModal = () => setIsOpenModal((prev) => !prev);
   const rankerValue = contents as IRankerState[];
 
-  const rankingList = [
-    { rank: 1, nickname: '오마카세에대출땡', amount: 24 },
-    { rank: 2, nickname: '지니지니', amount: 14 },
-    { rank: 3, nickname: '오마카새우', amount: 8 },
-    { rank: 4, nickname: '오마카사위', amount: 3 },
-    { rank: 5, nickname: '오마카사위', amount: 3 },
-    { rank: 6, nickname: '오마카사위', amount: 3 },
-    { rank: 7, nickname: '오마카사위', amount: 3 },
-    { rank: 8, nickname: '오마카사위', amount: 3 },
-    { rank: 9, nickname: '오마카사위', amount: 3 },
-    { rank: 10, nickname: '오마카사위', amount: 3 },
-  ];
-  if (state === 'loading') return 'dd';
-  console.log(rankerValue);
+  if (state === 'loading') return '랭킹 불러오는중..';
+
   return (
     <Layout title="Ranking" noHeader>
       <OmakasePioneerSection>

--- a/src/recoil/rankerState.ts
+++ b/src/recoil/rankerState.ts
@@ -22,12 +22,12 @@ const defaultRankerState: IRankerState = {
   email: '',
 };
 
-export const rankerState = atom<IRankerState>({
+const rankerState = atom<IRankerState>({
   key: 'rankerState',
   default: defaultRankerState,
 });
 
-export const rankerAsyncState = selector({
+const rankerAsyncState = selector({
   key: 'rankerAsyncState',
   get: async () => {
     try {

--- a/src/recoil/rankerState.ts
+++ b/src/recoil/rankerState.ts
@@ -32,7 +32,6 @@ export const rankerAsyncState = selector({
   get: async () => {
     try {
       const response = await requestRankers(rankingLimit);
-      console.dir(response);
       return response.data;
     } catch (error) {
       if (!(error instanceof Error)) return;

--- a/src/recoil/rankerState.ts
+++ b/src/recoil/rankerState.ts
@@ -1,0 +1,40 @@
+import { atom, selector, useRecoilValueLoadable } from 'recoil';
+
+import { requestRankers } from '@request';
+
+const rankingLimit = 10;
+
+export interface IRankerState {
+  ranking: number;
+  nickname: string;
+  stampCount: number;
+  profileUrl: string | null;
+}
+
+const defaultRankerState: IRankerState = {
+  ranking: 0,
+  nickname: '',
+  stampCount: 0,
+  profileUrl: null,
+};
+
+export const rankerState = atom<IRankerState>({
+  key: 'rankerState',
+  default: defaultRankerState,
+});
+
+export const rankerAsyncState = selector({
+  key: 'rankerAsyncState',
+  get: async () => {
+    try {
+      const response = await requestRankers(rankingLimit);
+      console.dir(response);
+      return response.data;
+    } catch (error) {
+      if (!(error instanceof Error)) return;
+      throw new Error(error.message);
+    }
+  },
+});
+
+export const useRankerRecoilValue = () => useRecoilValueLoadable(rankerAsyncState);

--- a/src/recoil/rankerState.ts
+++ b/src/recoil/rankerState.ts
@@ -9,6 +9,8 @@ export interface IRankerState {
   nickname: string;
   stampCount: number;
   profileUrl: string | null;
+  power: number;
+  email: string;
 }
 
 const defaultRankerState: IRankerState = {
@@ -16,6 +18,8 @@ const defaultRankerState: IRankerState = {
   nickname: '',
   stampCount: 0,
   profileUrl: null,
+  power: 1,
+  email: '',
 };
 
 export const rankerState = atom<IRankerState>({

--- a/src/recoil/rankerState.ts
+++ b/src/recoil/rankerState.ts
@@ -1,4 +1,4 @@
-import { atom, selector, useRecoilValueLoadable } from 'recoil';
+import { selector, useRecoilValueLoadable } from 'recoil';
 
 import { requestRankers } from '@request';
 
@@ -12,20 +12,6 @@ export interface IRankerState {
   power: number;
   email: string;
 }
-
-const defaultRankerState: IRankerState = {
-  ranking: 0,
-  nickname: '',
-  stampCount: 0,
-  profileUrl: null,
-  power: 1,
-  email: '',
-};
-
-const rankerState = atom<IRankerState>({
-  key: 'rankerState',
-  default: defaultRankerState,
-});
 
 const rankerValue = selector({
   key: 'rankerValue',

--- a/src/recoil/rankerState.ts
+++ b/src/recoil/rankerState.ts
@@ -27,8 +27,8 @@ const rankerState = atom<IRankerState>({
   default: defaultRankerState,
 });
 
-const rankerAsyncState = selector({
-  key: 'rankerAsyncState',
+const rankerValue = selector({
+  key: 'rankerValue',
   get: async () => {
     try {
       const response = await requestRankers(rankingLimit);
@@ -40,4 +40,4 @@ const rankerAsyncState = selector({
   },
 });
 
-export const useRankerRecoilValue = () => useRecoilValueLoadable(rankerAsyncState);
+export const useRankerRecoilValue = () => useRecoilValueLoadable(rankerValue);

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { IRankerState } from '@recoil/rankerState';
+
 interface IRequestStampBody {
   omakaseId: number;
   receiptIssuaranceData: string;
@@ -30,7 +32,8 @@ export const requestOmakases = (param: IRequestOmakasesBody) => {
 export const requestSpecificOmakase = (id: number) => instance.get(`/omakases?/${id}`);
 export const requestLike = (id: number) => instance.patch(`/recommendation/${id}`);
 export const requestMyRanking = () => instance.get(`/my-ranking`);
-export const requestRankers = (limit?: number) => instance.get(`/rankers/?limit=${limit}`);
+export const requestRankers = (limit?: number) =>
+  instance.get<IRankerState[]>(`/rankers?limit=${limit}`);
 export const requestMyInfo = () => instance.get(`/user`);
 export const requestUserInfo = (email?: string) => instance.get(`/user/${email}`);
 export const requestMyOmakase = (email?: string) => instance.get(`/my-omakase/${email}`);


### PR DESCRIPTION
## :bookmark_tabs: 제목
<img src="https://user-images.githubusercontent.com/60775453/142891403-4b69aa66-14b7-41fd-a6d3-e5e7c68a19cb.png" width="50%" />
- ranking 페이지에서 보여줄 랭킹 리스트 api 연동
- logout api 연동도 포함되어 있네용

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] rankerState 작성
- [x] rankerState를 불러오는 ranking페이지에서 any타입으로 평가되어 IRankerState로 강제 형변환
- [x] dummydata를 지우고 실제 데이터인 rankerValue로 변경

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- loading중 임시로 처리
- 랭킹은 10명만 보여주게 설정, 변경 원하면 rankingLimit 변수 값 변경을 통해 변경하면 됨
- logout api 연동 로직은 작성했는데 실제로 로그아웃이 안됨..

