### PR TITLE
Feature/omo 109/searching logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "next": "11.1.2",
         "react": "17.0.2",
         "react-dom": "17.0.2",
+        "react-toastify": "^8.1.0",
         "recoil": "^0.4.1",
         "styled-components": "^5.3.1",
         "styled-reset": "^4.3.4"
@@ -3127,6 +3128,14 @@
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
+    "node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/coa": {
       "version": "2.0.2",
@@ -6504,6 +6513,18 @@
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.1.0.tgz",
+      "integrity": "sha512-M+Q3rTmEw/53Csr7NsV/YnldJe4c7uERcY7Tma9mvLU98QT2VhIkKwjBzzxZkJRk/oBKyUAtkyMjMgO00hx6gQ==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/readable-stream": {
@@ -9974,6 +9995,11 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "coa": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -12633,6 +12659,14 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
+    },
+    "react-toastify": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.1.0.tgz",
+      "integrity": "sha512-M+Q3rTmEw/53Csr7NsV/YnldJe4c7uERcY7Tma9mvLU98QT2VhIkKwjBzzxZkJRk/oBKyUAtkyMjMgO00hx6gQ==",
+      "requires": {
+        "clsx": "^1.1.1"
+      }
     },
     "readable-stream": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "next": "11.1.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-toastify": "^8.1.0",
     "recoil": "^0.4.1",
     "styled-components": "^5.3.1",
     "styled-reset": "^4.3.4"

--- a/src/components/Certification/SearchBottomActionSheet.tsx
+++ b/src/components/Certification/SearchBottomActionSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 
 import CloseIcon from '@assets/close.svg';
@@ -9,12 +9,10 @@ import { omakaseKeywordState } from '@recoil/omakaseState';
 import * as S from './styles';
 
 type SearchBottomActionSheetProps = {
-  isActionSheetActive: boolean;
   handleClickOnReselectLocation: () => void;
 };
 
 const SearchBottomActionSheet = ({
-  isActionSheetActive,
   handleClickOnReselectLocation,
 }: SearchBottomActionSheetProps) => {
   const [searchKeyword, setSearchKeyword] = useState('');
@@ -32,19 +30,10 @@ const SearchBottomActionSheet = ({
   };
 
   const handleClickOnCloseBtn = () => {
+    setSearchKeyword('');
     setKeyword('');
     handleClickOnReselectLocation();
   };
-
-  const handleClickOnNewStoreDisplay = () => {
-    handleClickOnCloseBtn();
-  };
-
-  useEffect(() => {
-    if (isActionSheetActive) {
-      // api call
-    }
-  }, [isActionSheetActive]);
 
   return (
     <S.SearchBottomActionSheet>
@@ -59,11 +48,13 @@ const SearchBottomActionSheet = ({
           value={searchKeyword}
           onChange={handleChangeOnInput}
         />
-        <SearchIcon onClick={() => handleClickOnSearchIcon()} />
+        <SearchIcon onClick={handleClickOnSearchIcon} />
       </S.SearchInputBar>
 
       <S.SearchResults>
-        <SearchResultsWithPreventLinking />
+        <SearchResultsWithPreventLinking
+          handleClickOnReselectLocation={handleClickOnReselectLocation}
+        />
       </S.SearchResults>
     </S.SearchBottomActionSheet>
   );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -6,14 +6,15 @@ import * as S from './styles';
 
 interface HeaderProps {
   title?: string;
+  backHandler?: () => void;
 }
 
-const Header = ({ title }: HeaderProps) => {
+const Header = ({ title, backHandler }: HeaderProps) => {
   const router = useRouter();
 
   return (
     <S.Header className="container">
-      <S.PrevButton onClick={() => router.back()}>
+      <S.PrevButton onClick={backHandler ?? router.back}>
         <Prev />
       </S.PrevButton>
       {title && <S.Title>{title}</S.Title>}

--- a/src/components/SearchNoData/styles.ts
+++ b/src/components/SearchNoData/styles.ts
@@ -6,6 +6,7 @@ export const NoData = styled.div`
   justify-content: center;
   align-items: center;
   height: 100%;
+  margin-top: 100px;
 
   .guide-message-wrapper {
     margin-top: 66px;

--- a/src/components/SearchResults/styles.ts
+++ b/src/components/SearchResults/styles.ts
@@ -16,7 +16,5 @@ export const LoadingSection = styled.div`
 export const NoDataWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
   flex: 1;
 `;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,8 @@
+import 'react-toastify/dist/ReactToastify.min.css';
+
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
+import { ToastContainer } from 'react-toastify';
 import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 
@@ -19,6 +22,7 @@ function App({ Component, pageProps }: AppProps) {
         <GlobalStyle />
         <ThemeProvider theme={theme}>
           <Component {...pageProps} />
+          <ToastContainer limit={1} />
         </ThemeProvider>
       </RecoilRoot>
     </>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,7 +14,6 @@ function App({ Component, pageProps }: AppProps) {
           name="viewport"
           content="viewport-fit=cover, width=device-width, height=device-height, initial-scale=1, maximum-scale=1.0, minimum-scale=1, user-scalable=0"
         />
-        <meta httpEquiv="Content-Security-Policy" content="upgrade-insecure-requests" />
       </Head>
       <RecoilRoot>
         <GlobalStyle />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,6 +14,7 @@ function App({ Component, pageProps }: AppProps) {
           name="viewport"
           content="viewport-fit=cover, width=device-width, height=device-height, initial-scale=1, maximum-scale=1.0, minimum-scale=1, user-scalable=0"
         />
+        <meta httpEquiv="Content-Security-Policy" content="upgrade-insecure-requests" />
       </Head>
       <RecoilRoot>
         <GlobalStyle />

--- a/src/pages/certification/index.tsx
+++ b/src/pages/certification/index.tsx
@@ -18,7 +18,7 @@ import { Omakase, currentOmakaseQuery, currentOmakaseState } from '@recoil/omaka
 import { requestStamp } from '@request';
 
 const Certification = () => {
-  const { query } = useRouter();
+  const { push, query } = useRouter();
   const { id } = query;
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isActionSheetActive, setIsActionSheetActive] = useState(false);
@@ -29,6 +29,10 @@ const Certification = () => {
 
   const handleClickOnReselectLocation = () => {
     setIsActionSheetActive((prev) => !prev);
+  };
+
+  const handleGoBack = () => {
+    push(`/search/${id}`);
   };
 
   useEffect(() => {
@@ -59,7 +63,7 @@ const Certification = () => {
 
   return (
     <CertificationPage isActionSheetActive={isActionSheetActive}>
-      <Header title="인증확인" />
+      <Header title="인증확인" backHandler={handleGoBack} />
       <CertificationMain className="container">
         <LocationChecker
           image={omakase.image_url}

--- a/src/pages/certification/index.tsx
+++ b/src/pages/certification/index.tsx
@@ -79,10 +79,7 @@ const Certification = () => {
       </CertificationMain>
 
       {isModalOpen && <CertificationModal name={omakase.name} />}
-      <SearchBottomActionSheet
-        isActionSheetActive={isActionSheetActive}
-        handleClickOnReselectLocation={handleClickOnReselectLocation}
-      />
+      <SearchBottomActionSheet handleClickOnReselectLocation={handleClickOnReselectLocation} />
     </CertificationPage>
   );
 };

--- a/src/pages/search/[id].tsx
+++ b/src/pages/search/[id].tsx
@@ -21,6 +21,10 @@ const Detail = () => {
   const [likeCount, setLikeCount] = useState<number>(contents?.recommendation_count ?? 0);
   const refresh = useResetRecoilState(currentOmakaseQuery(Number(id)));
 
+  const handleGoBack = () => {
+    router.push('/search');
+  };
+
   useEffect(() => {
     return () => refresh();
   }, [refresh]);
@@ -48,7 +52,7 @@ const Detail = () => {
 
   return (
     <DetailPage>
-      <Header />
+      <Header backHandler={handleGoBack} />
       <ImageWrapper>
         <Image src={omakase.image_url} alt="가게 이미지" layout="fill" />
       </ImageWrapper>

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
-import { IRankerState } from '@recoil/rankerState';
+
 import { Omakases } from '@recoil/omakaseState';
+import { IRankerState } from '@recoil/rankerState';
 
 interface IRequestStampBody {
   omakaseId: number;
@@ -72,3 +73,6 @@ export const requestChangeProfilePhoto = (image: File) => {
   return instance.patch(`/user/profile`, formData);
 };
 export const requestUserProfile = () => instance.get(`/user/profile`);
+
+export const requestCheckOmakaseIsCertificated = (id: number) =>
+  instance.get(`/omakase/check?id=${id}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,6 +1854,11 @@
   "resolved" "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz"
   "version" "2.2.6"
 
+"clsx@^1.1.1":
+  "integrity" "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+  "resolved" "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz"
+  "version" "1.1.1"
+
 "coa@^2.0.2":
   "integrity" "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA=="
   "resolved" "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz"
@@ -3946,7 +3951,7 @@
     "iconv-lite" "0.4.24"
     "unpipe" "1.0.0"
 
-"react-dom@^17.0.2", "react-dom@>= 16.8.0", "react-dom@17.0.2":
+"react-dom@^17.0.2", "react-dom@>= 16.8.0", "react-dom@>=16", "react-dom@17.0.2":
   "integrity" "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA=="
   "resolved" "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz"
   "version" "17.0.2"
@@ -3970,7 +3975,14 @@
   "resolved" "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz"
   "version" "0.8.3"
 
-"react@^16.8.0 || ^17.0.0", "react@^17.0.2", "react@>= 16.8.0", "react@>= 16.8.0 || 17.x.x || 18.x.x", "react@>=16.13.1", "react@17.0.2":
+"react-toastify@^8.1.0":
+  "integrity" "sha512-M+Q3rTmEw/53Csr7NsV/YnldJe4c7uERcY7Tma9mvLU98QT2VhIkKwjBzzxZkJRk/oBKyUAtkyMjMgO00hx6gQ=="
+  "resolved" "https://registry.npmjs.org/react-toastify/-/react-toastify-8.1.0.tgz"
+  "version" "8.1.0"
+  dependencies:
+    "clsx" "^1.1.1"
+
+"react@^16.8.0 || ^17.0.0", "react@^17.0.2", "react@>= 16.8.0", "react@>= 16.8.0 || 17.x.x || 18.x.x", "react@>=16", "react@>=16.13.1", "react@17.0.2":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"


### PR DESCRIPTION
## :bookmark_tabs: 제목


- 오마카세 재선택 로직 개선


https://user-images.githubusercontent.com/48883344/144082319-6a9a1a2d-38c6-4781-a4f5-2a19949e9c1e.mp4



https://user-images.githubusercontent.com/48883344/144743903-93f930e8-3761-4613-ab20-507966fd23f8.mp4


## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 바텀시트의 검색결과 컴포넌트 재작성 - 기존 SearchResults 컴포넌트와 유사하지만 다른 로직이 필요
- [x] 선택 시 해당 오마카세 상세보기로 이동하는 것이 아니라 선택된 상태값을 변경하도록 수정
- [x] 수정된 오마카세로 인증하기
- [x] 이미 인증 중인 오마카세의 경우 에러메시지 출력 (react-toastify 이용)
- [x] react-toastify 패키지 설치 
- [x] Header 레이아웃의 경우 backHandler 옵셔널 props 추가 

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- ~추후 승윤님이 내가 인증한 오마카세 목록인지 검증하는 API 작업 완료되면 클릭 시 validation 으로 내가 이미 인증했거나, 인증이 진행중인 오마카세인 경우엔 선택되지 않도록 해야 합니다~
- react-toastify 패키지 설치되어서 npm install 또는 yarn 명령어 실행 해주셔야 합니다~